### PR TITLE
Add hooks to the NativeImageRenderer used in VtkRenderer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraviewweb",
-  "version": "0.0.11-20210325-2",
+  "version": "0.0.11-20210402",
   "description": "Web framework for building interactive visualization relying on VTK or ParaView to produce visualization data",
   "repository": {
     "type": "git",

--- a/src/IO/WebSocket/WslinkImageStream/index.js
+++ b/src/IO/WebSocket/WslinkImageStream/index.js
@@ -58,14 +58,14 @@ function wslinkImageStream(publicAPI, model) {
   publicAPI.unsubscribeRenderTopic = () => {
     if (model.renderTopicSubscription) {
       model.client.VtkImageDelivery.offRenderChange(
-          model.renderTopicSubscription
+        model.renderTopicSubscription
       ).then(
-          (unsubSuccess) => {
-              console.log('Unsubscribe resolved ', unsubSuccess);
-          },
-          (unsubFailure) => {
-              console.log('Unsubscribe error ', unsubFailure);
-          }
+        (unsubSuccess) => {
+          console.log('Unsubscribe resolved ', unsubSuccess);
+        },
+        (unsubFailure) => {
+          console.log('Unsubscribe error ', unsubFailure);
+        }
       );
     }
   };
@@ -141,6 +141,7 @@ function wslinkImageStream(publicAPI, model) {
         id: msg.id,
         memory: msg.memsize,
         workTime: msg.workTime,
+        cameraInfo: msg.camera,
       },
     };
 

--- a/src/NativeUI/Renderers/NativeImageRenderer/index.js
+++ b/src/NativeUI/Renderers/NativeImageRenderer/index.js
@@ -22,12 +22,14 @@ export default class NativeImageRenderer {
     domElement,
     imageProvider,
     mouseListeners = null,
-    drawFPS = true
+    drawFPS = true,
+    canvas = null,
+    onImageDraw = null,
   ) {
     this.size = domElement
       ? SizeHelper.getSize(domElement)
       : { clientWidth: 400, clientHeight: 400 };
-    this.canvas = document.createElement('canvas');
+    this.canvas = canvas ? canvas : document.createElement('canvas');
     this.image = new Image();
     this.fps = '';
     this.drawFPS = drawFPS;
@@ -35,6 +37,8 @@ export default class NativeImageRenderer {
     this.imageProvider = imageProvider;
     this.fpsBuffer = [];
     this.fpsBufferSize = 30;
+
+    this.onImageDraw = onImageDraw;
 
     this.image.onload = () => {
       this.updateDrawnImage();
@@ -63,6 +67,7 @@ export default class NativeImageRenderer {
         while (this.fpsBufferSize < this.fpsBuffer.length) {
           this.fpsBuffer.shift();
         }
+        this.cameraInfo = data.metadata.cameraInfo;
       })
     );
 
@@ -166,6 +171,9 @@ export default class NativeImageRenderer {
         this.size.clientWidth - 5,
         5
       );
+    }
+    if (this.onImageDraw) {
+      this.onImageDraw(this);
     }
   }
 }

--- a/src/React/Renderers/VtkRenderer/index.js
+++ b/src/React/Renderers/VtkRenderer/index.js
@@ -41,7 +41,7 @@ export default class VtkRenderer extends React.Component {
     if (prevProps.client !== this.props.client) {
       this.mouseListener = new VtkWebMouseListener(this.props.client);
 
-      // Attach interaction listener for image qualitya
+      // Attach interaction listener for image quality
       this.mouseListener.onInteraction((interact) => {
         if (this.props.onInteraction) {
           this.props.onInteraction(interact);
@@ -93,7 +93,9 @@ export default class VtkRenderer extends React.Component {
         container,
         this.binaryImageStream,
         this.mouseListener.getListeners(),
-        this.props.showFPS
+        this.props.showFPS,
+        this.props.canvas,
+        this.props.onImageDraw
       );
 
       // Establish image stream connection
@@ -199,6 +201,14 @@ VtkRenderer.propTypes = {
   // Takes a single boolean arg. The arg is true for a mouse down, false for a
   // mouse up event.
   onInteraction: PropTypes.func,
+
+  // Optional callback that runs when the image renderer draws an image.
+  // Takes a single arg, which is the renderer (NativeImageRenderer).
+  onImageDraw: PropTypes.func,
+
+  // The HTMLCanvasElement for the image renderer to use.
+  // If not specified, the renderer will create and use its own canvas.
+  canvas: PropTypes.object,
 };
 
 VtkRenderer.defaultProps = {


### PR DESCRIPTION
Now, it can register a callback whenever the image is drawn.
Also, the creator can specify a canvas for it to use rather than
creating its own canvas.